### PR TITLE
add electron page to the navigation

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -13,6 +13,13 @@
   {% endif %}
     articles
   </a>
+  {% if page.url == '/electron' or page.url == '/electron.html' %}
+    <a href="/electron" class="active">
+  {% else %}
+    <a href="/electron">
+  {% endif %}
+    Electron
+  </a>
   <!-- {% if page.url == '/moocs' or page.url == '/moocs.html' %}
   <a href="/moocs" class="active">
   {% else %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{ site.data.theme.name }} - {{ page.title }}</title>
+  <title>{{ page.title }}</title>
   <meta name="author" content="{{ site.data.theme.name }}" />
   <meta name="description" content="The blog of {{ site.data.theme.name }}" />
   <meta name="keywords" content="{{ page.keywords }}">
@@ -16,12 +16,6 @@
   <link href="https://fonts.googleapis.com/css?family=Lora:400,400italic,700,700italic|PT+Sans+Caption:700,400|Source+Sans+Pro:400|Raleway:300" rel="stylesheet" type="text/css">
   <link rel="shortcut icon" href="/favicon.png">
   <link rel="alternate" type="application/atom+xml" title="{{ site.data.theme.name }}" href="{{site.url}}/atom.xml" />
-
-  <meta name="twitter:card" content="summary">
-  <meta name="twitter:site" content="@blooomca">
-  <meta name="twitter:title" content="{{ page.title }}">
-  <meta name="twitter:description" content="Blog about programming">
-  <meta name="twitter:image" content="http://www.gravatar.com/avatar/{{ site.data.theme.social.gravatar }}?s=200">
 
   <link rel="stylesheet" href="/assets/css/all.css">
 </head>

--- a/electron.html
+++ b/electron.html
@@ -1,0 +1,26 @@
+---
+layout: default
+title: Electron
+---
+
+<h1>Electron.js Overview Guide</h1>
+
+<p>
+    When I started working on the Electron applications, coming from the web, a lot of things were really confusing. What is the "DOM" of native GUI development? What exactly is the difference between platforms? What is a set of "normal" Desktop features, and where exactly are they defined?
+</p>
+<p>
+    This guide won't answer all of these questions, but it should give a solid overview of what a typical native application has in terms of the OS integration.
+</p>
+
+<ul>
+    <li><a href="/2025/07/13/electron-overview">What is Electron?</a></li>
+    <li><a href="/2025/07/13/how-to-load-your-web-app-electron">How to load your web application in Electron</a></li>
+    <li>Managing windows in Electron apps</li>
+    <li><a href="/2025/07/20/electron-apps-custom-protocols">Custom Protocols and Deeplinking in Electron apps</a></li>
+    <li><a href="/2025/07/20/electron-notifications">Electron Notifications</a></li>
+    <li><a href="/2025/07/20/menus-in-electron">Menus in Electron apps -- Application, Tray, Context</a></li>
+    <li><a href="/2025/07/21/multi-window-in-electron">Multiple Windows in Electron apps</a></li>
+    <li><a href="/2025/07/21/how-desktop-apps-built-packaged">How Desktop apps are built and packaged</a></li>
+    <li>Codesigning apps on macOS</li>
+    <li>How auto-updating works in Desktop applications</li>
+</ul>


### PR DESCRIPTION
## Description

Add Electron page to the navigation and add a list of all articles so far to it. I haven't added any unwritten articles yet, just in case someone would wait for it, and I simply decide not to do it. Honestly it is already pretty good, the goal is to be quite high level, so I don't want to dive into some super specific details too much.